### PR TITLE
Feature/Make compatible with fzf completion

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -2,10 +2,10 @@ if (( ${+commands[fd]} )); then
   export FZF_DEFAULT_COMMAND='command fd -c always -H --no-ignore-vcs -E .git -tf'
   export FZF_ALT_C_COMMAND='command fd -c always -H --no-ignore-vcs -E .git -td'
   _fzf_compgen_path() {
-    command fd -c always -H --no-ignore-vcs -E .git -tf "${1}"
+    command fd -c always -H --no-ignore-vcs -E .git -tf . "${1}"
   }
   _fzf_compgen_dir() {
-    command fd -c always -H --no-ignore-vcs -E .git -td "${1}"
+    command fd -c always -H --no-ignore-vcs -E .git -td . "${1}"
   }
   export FZF_DEFAULT_OPTS="--ansi ${FZF_DEFAULT_OPTS}"
 elif (( ${+commands[rg]} )); then


### PR DESCRIPTION
# Problem

After integrating [FZF's completion](https://github.com/junegunn/fzf/blob/master/shell/completion.zsh) plugin, triggering completion for directories with `** <TAB>` gave an error:

```sh
$ cd path/to/dir/** <TAB>
[fd error]: The search pattern 'path/to/dir' contains a path-separation character ('/') and will not lead to any search results.

If you want to search for all files inside the 'path/to/dir' directory, use a match-all pattern:

  fd . 'path/to/dir'

Instead, if you want your pattern to match the full file path, use:

  fd --full-path 'path/to/dir'
```

This also applied to files completion, e.g:

```sh
$ vim /path/to/file/** <TAB>
```

# Solution

Add match-all pattern to `fd` command in `_fzf_compgen_path` and `_fzf_compgen_dir` functions