### PR TITLE
Hide error messages

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,6 +1,6 @@
 if (( ${+commands[bfs]} )); then
-  export FZF_DEFAULT_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d,f -printf '%P\n'"
-  export FZF_ALT_C_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d -printf '%P\n'"
+  export FZF_DEFAULT_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d,f -printf '%P\n' 2> /dev/null"
+  export FZF_ALT_C_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d -printf '%P\n' 2> /dev/null"
   _fzf_compgen_path() {
     command bfs ${1} -exclude -name .git -type d,f -a -not -path ${1} -print
   }
@@ -17,7 +17,7 @@ elif (( ${+commands[fd]} )); then
     command fd -H --no-ignore-vcs -E .git -td . ${1}
   }
 elif (( ${+commands[rg]} )); then
-  export FZF_DEFAULT_COMMAND="command rg -uu -g '!.git' --files"
+  export FZF_DEFAULT_COMMAND="command rg -uu -g '!.git' --files --no-messages"
   _fzf_compgen_path() {
     command rg -uu -g '!.git' --files ${1}
   }

--- a/init.zsh
+++ b/init.zsh
@@ -1,6 +1,6 @@
 if (( ${+commands[bfs]} )); then
-  export FZF_DEFAULT_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d,f -printf '%P\n' 2> /dev/null"
-  export FZF_ALT_C_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d -printf '%P\n' 2> /dev/null"
+  export FZF_DEFAULT_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d,f -printf '%P\n' 2>/dev/null"
+  export FZF_ALT_C_COMMAND="command bfs -mindepth 1 -exclude -name .git -type d -printf '%P\n' 2>/dev/null"
   _fzf_compgen_path() {
     command bfs ${1} -exclude -name .git -type d,f -a -not -path ${1} -print
   }


### PR DESCRIPTION
When permission errors are encountered both ripgrep and bfs print messages to `stderr`, but that scrambles fzf's output. Disable messages when using ripgrep, pipe `stderr` to `/dev/null` when using bfs.