### PR TITLE
prevent "command not found" message if fzf missing

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,6 +1,7 @@
 () {
   local -r target=${1}
   shift
+  (( ${+commands[${1}]} )) || return 1
   if [[ ! ( -s ${target} && ${target} -nt ${commands[${1}]} ) ]]; then
     "${@}" >! ${target} || return 1
     zcompile -UR ${target}


### PR DESCRIPTION
Without fzf installed, the user will currenlty get an annoying message when they start their shell:

    zsh: command not found: fzf

This change first checks for fzf to be installed before either generating and/or sourcing the cached `fzf` script.

This makes for a nicer experience when copying my dotfiles to a new machine, or someone copies my dotfiles to try them out (my `~/.zshrc` does feature detection to gracefully handle the lack of any tools it would otherwise like to sue, and this is the last remaining piece that misbehaves).